### PR TITLE
run button enabled when status is interrupted

### DIFF
--- a/src/components/run-button.js
+++ b/src/components/run-button.js
@@ -14,6 +14,7 @@ function isDisabled(taskStatus) {
     return (
         taskStatus !== 'READY' &&
         taskStatus !== 'SUCCESS' &&
+        taskStatus !== 'INTERRUPTED' &&
         taskStatus !== 'ERROR'
     );
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
The run button is disabled when the task status is interrupted so it's not possible to run an interrupted process.


**What is the new behavior (if this is a feature change)?**
Run button is enabled when the task status is interrupted.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
