### PR TITLE
Use CardErrorBoundary to display errors

### DIFF
--- a/src/components/app-wrapper.js
+++ b/src/components/app-wrapper.js
@@ -13,12 +13,15 @@ import {
     StyledEngineProvider,
 } from '@mui/material/styles';
 import {
+    CardErrorBoundary,
     LIGHT_THEME,
     login_en,
     login_fr,
     SnackbarProvider,
     top_bar_en,
     top_bar_fr,
+    card_error_boundary_fr,
+    card_error_boundary_en,
 } from '@gridsuite/commons-ui';
 import { IntlProvider } from 'react-intl';
 import { BrowserRouter } from 'react-router-dom';
@@ -92,8 +95,20 @@ const getMuiTheme = (theme) => {
 };
 
 const messages = {
-    en: { ...messages_en, ...labels_en, ...login_en, ...top_bar_en },
-    fr: { ...messages_fr, ...labels_fr, ...login_fr, ...top_bar_fr },
+    en: {
+        ...messages_en,
+        ...labels_en,
+        ...login_en,
+        ...top_bar_en,
+        ...card_error_boundary_en,
+    },
+    fr: {
+        ...messages_fr,
+        ...labels_fr,
+        ...login_fr,
+        ...top_bar_fr,
+        ...card_error_boundary_fr,
+    },
 };
 
 const basename = new URL(document.querySelector('base').href).pathname;
@@ -113,7 +128,9 @@ const AppWrapperWithRedux = () => {
                     <ThemeProvider theme={getMuiTheme(theme)}>
                         <SnackbarProvider hideIconVariant={false}>
                             <CssBaseline />
-                            <App />
+                            <CardErrorBoundary>
+                                <App />
+                            </CardErrorBoundary>
                         </SnackbarProvider>
                     </ThemeProvider>
                 </StyledEngineProvider>

--- a/src/components/app.test.js
+++ b/src/components/app.test.js
@@ -19,7 +19,7 @@ import {
     ThemeProvider,
     StyledEngineProvider,
 } from '@mui/material/styles';
-import { SnackbarProvider } from '@gridsuite/commons-ui';
+import { CardErrorBoundary, SnackbarProvider } from '@gridsuite/commons-ui';
 import CssBaseline from '@mui/material/CssBaseline';
 
 let container = null;
@@ -49,7 +49,9 @@ it('renders', async () => {
                             <ThemeProvider theme={createTheme({})}>
                                 <SnackbarProvider hideIconVariant={false}>
                                     <CssBaseline />
-                                    <App />
+                                    <CardErrorBoundary>
+                                        <App />
+                                    </CardErrorBoundary>
                                 </SnackbarProvider>
                             </ThemeProvider>
                         </StyledEngineProvider>


### PR DESCRIPTION
When an untreated error occurs we have a blank page like this

![Capture d’écran de 2023-11-20 12-39-39](https://github.com/farao-community/gridcapa-app/assets/116628858/29284e87-a7ff-4593-a159-3af89eba1518)

Now we will see this CardErrorBoundary which will give us more information on the error

![Capture d’écran de 2023-11-20 12-39-17](https://github.com/farao-community/gridcapa-app/assets/116628858/9a304507-e2dd-456c-bd25-eb5d37eb8c96)

