### PR TITLE
Add loading when dowloading file

### DIFF
--- a/src/components/buttons/download-button.js
+++ b/src/components/buttons/download-button.js
@@ -1,15 +1,21 @@
 /**
- * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Button } from '@mui/material';
-import { GetApp } from '@mui/icons-material';
+import React, { useState } from 'react';
+
+import PropTypes from 'prop-types';
+
 import { useSnackbar } from 'notistack';
-import { useIntlRef } from '../utils/messages';
-import { fetchFileFromProcess } from '../utils/rest-api';
+import { useIntlRef } from '../../utils/messages';
+
+import { Button, CircularProgress } from '@mui/material';
+import { GetApp } from '@mui/icons-material';
+
+import { fetchFileFromProcess } from '../../utils/rest-api';
 
 async function downloadFile(processFile, timestamp, intlRef, enqueueSnackbar) {
     const blob = await fetchFileFromProcess(
@@ -28,20 +34,32 @@ async function downloadFile(processFile, timestamp, intlRef, enqueueSnackbar) {
 const DownloadButton = ({ processFile, timestamp }) => {
     const intlRef = useIntlRef();
     const { enqueueSnackbar } = useSnackbar();
-    return processFile.fileUrl === null ? (
-        ''
+
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = async () => {
+        setIsLoading(true);
+        await downloadFile(processFile, timestamp, intlRef, enqueueSnackbar);
+        setIsLoading(false);
+    };
+
+    return processFile.fileUrl === null ? null : isLoading ? (
+        <CircularProgress size={30} />
     ) : (
         <Button
             data-test={
                 'download-' + processFile.fileType + '-' + Date.parse(timestamp)
             }
-            onClick={() =>
-                downloadFile(processFile, timestamp, intlRef, enqueueSnackbar)
-            }
+            onClick={handleClick}
         >
             <GetApp />
         </Button>
     );
+};
+
+DownloadButton.propTypes = {
+    processFile: PropTypes.object.isRequired,
+    timestamp: PropTypes.string.isRequired,
 };
 
 export default DownloadButton;

--- a/src/components/overview-table.js
+++ b/src/components/overview-table.js
@@ -17,7 +17,7 @@ import {
 } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import { gridcapaFormatDate } from '../utils/commons';
-import DownloadButton from './download-button';
+import DownloadButton from './buttons/download-button';
 import UploadButton from './upload-button';
 
 const INPUT_FILE_GROUP = 'input';
@@ -118,7 +118,10 @@ function FileDataRow({ processFile, fileGroup, timestamp }) {
             >
                 {lastModificationDate}
             </TableCell>
-            <TableCell data-test={fileType + '-' + fileGroup + '-latest-url'}>
+            <TableCell
+                data-test={fileType + '-' + fileGroup + '-latest-url'}
+                align="center"
+            >
                 <DownloadButton
                     processFile={processFile}
                     timestamp={timestamp}
@@ -127,6 +130,7 @@ function FileDataRow({ processFile, fileGroup, timestamp }) {
             {fileGroup === INPUT_FILE_GROUP && ( // never use null as false
                 <TableCell
                     data-test={fileType + '-' + fileGroup + '-latest-url'}
+                    align="center"
                 >
                     <UploadButton
                         processFile={processFile}


### PR DESCRIPTION
Sometimes downloading a file takes too long and it seems like the click didn't work. We therefore added a loading to understand that the download is in progress

![Capture d’écran de 2024-02-01 17-33-27](https://github.com/farao-community/gridcapa-app/assets/116628858/cd138774-2515-42b3-a972-c2b50e8d8c9a)
