### PR TITLE
Add a documentation button in the app topbar

### DIFF
--- a/public/documentation-config.json
+++ b/public/documentation-config.json
@@ -1,0 +1,4 @@
+{
+  "displayDocumentationButton": true,
+  "documentationUrl": "https://gridcapa.github.io"
+}

--- a/src/components/app-top-bar.jsx
+++ b/src/components/app-top-bar.jsx
@@ -25,9 +25,10 @@ import FaraoLogo from '../images/farao-logo.svg?react';
 import ViewTabs from './tabs/view-tabs';
 import ParametersButton from './buttons/parameters-button';
 import MinioDiskUsage from './minio-disk-usage';
-import { Box } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 import AppPackage from '../../package.json';
 import GridcapaLogoText from './gridcapa-logo-text';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 
 const AppTopBar = ({
     user,
@@ -45,6 +46,9 @@ const AppTopBar = ({
 
     const [appsAndUrls, setAppsAndUrls] = useState([]);
     const [showParameters, setShowParameters] = useState(false);
+    const [displayDocumentationButton, setDisplayDocumentationButton] =
+        useState(false);
+    const [documentationUrl, setDocumentationUrl] = useState('#');
 
     useEffect(() => {
         if (user !== null) {
@@ -65,6 +69,22 @@ const AppTopBar = ({
     const handleLogoClicked = () => {
         navigate('/', { replace: true });
     };
+
+    const handleDocumentationClick = () => {
+        window.open(documentationUrl);
+    };
+
+    useEffect(() => {
+        console.log('Fetching documentation config...');
+        fetch('documentation-config.json')
+            .then((res) => res.json())
+            .then((res) => {
+                setDisplayDocumentationButton(
+                    res.displayDocumentationButton || false
+                );
+                setDocumentationUrl(res.documentationUrl || '#');
+            });
+    }, []);
 
     return (
         <>
@@ -97,6 +117,12 @@ const AppTopBar = ({
                             <MinioDiskUsage />
                         </Box>
                         {parametersEnabled && <ParametersButton />}
+
+                        {displayDocumentationButton && (
+                            <IconButton onClick={handleDocumentationClick}>
+                                <MenuBookIcon />
+                            </IconButton>
+                        )}
                     </Box>
                 )}
             </TopBar>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional Documentation button to the top bar. When enabled via remote configuration, it appears and opens the external documentation site in a new tab.
  - Behavior is safe by default: if the configuration is missing or disabled, the button is hidden and the app behaves as before.
  - Remote configuration supports toggling visibility and updating the destination URL without a new app release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->